### PR TITLE
Update optical constant calculation

### DIFF
--- a/thzpy/frequencydomain/_frequencydomain.py
+++ b/thzpy/frequencydomain/_frequencydomain.py
@@ -9,8 +9,7 @@ import numpy as np
 
 def _n_complex(n, a, f):
     k = _extinction_coefficient(a, f)
-    return n - 1j*k
-
+    return n + 1j*k 
 
 def _extinction_coefficient(a, f):
     w = 2*np.pi*f
@@ -32,8 +31,13 @@ def _invert_dielectric_constant(e_complex):
 def _all_optical_constants(n, a, f, t, p):
     # Produce a dictionary of all optical constants.
 
-    k = _extinction_coefficient(a, f)
-    n_complex = _n_complex(n, a, f)
+    # convert units to SI
+    # define new parameters so that output parameters would not be affected    
+    f_hz = f*1e12 
+    a_m = a*100
+    
+    k = _extinction_coefficient(a_m, f_hz) 
+    n_complex = _n_complex(n, a_m, f_hz)
     e_complex = _dielectric_constant(n_complex)
 
     optical_constants = {"frequency": f,

--- a/thzpy/transferfunctions/transferfunctions.py
+++ b/thzpy/transferfunctions/transferfunctions.py
@@ -248,8 +248,8 @@ def binary_mixture(sample_thickness, reference_thickness,
     # Prepare optical constant values for returning.
     n_sam = _invert_dielectric_constant(e_sam)
     n = np.real(n_sam)
-    a = _absorption_coefficient(-np.imag(n_sam), freqs*1e12)
-
+    a = _absorption_coefficient(np.imag(n_sam), freqs*1e12)
+    
     # Return optical constants.
     if all_optical_constants:
         return _all_optical_constants(n, a, freqs, amp, phase)


### PR DESCRIPTION
1. Edit sign convention in _n_complex
2. Use SI units when calculating optical constants
3. Maintain outputs units in THz community convention, e.g. frequency in THz, absorption coefficient in cm-1
4. Adjust sign conventions in other defs accordingly 