### PR TITLE
Update halfwidth and units

### DIFF
--- a/examples/basic_thz.py
+++ b/examples/basic_thz.py
@@ -10,7 +10,7 @@ Data acquired on a Menlo TeraSmart by the Terahertz Applications Group
 at Cambridge University.
 """
 
-from thzpy.pydotthz import DotthzFile
+from thzpy.dotthz import DotthzFile
 from thzpy.timedomain import common_window
 from thzpy.transferfunctions import (uniform_slab,
                                      binary_mixture)
@@ -31,8 +31,9 @@ with DotthzFile(path, 'r') as file:
     measurement = file[names[0]]
 
     # Extract the sample and reference datasets.
-    # if the computation is outside of the file context, we need to copy the data using `np.array()` otherwise the pointer only
-    # lives as long as the file is opened (only inside this context here)
+    # If the computation is outside of the file context, we need to copy the
+    # data using `np.array()` otherwise the pointer only lives as long as the
+    # file is opened (only inside this context here).
     sample = np.array(measurement.datasets["Sample"])
     reference = np.array(measurement.datasets["Reference"])
     baseline = np.array(measurement.datasets["Baseline"])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ packages = ["thzpy", "thzpy.timedomain", "thzpy.transferfunctions", "thzpy.frequ
 
 [project]
 name = "thzpy"
-version = "0.0.6"
+version = "0.1.0"
 authors = [
     { name = "Jasper Ward-Berry", email = "jnw35@cam.ac.uk" },
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-pydotthz>=1.0.0
-numpy~=2.0.2
+pydotthz>=1.0.1
+numpy~=2.3.2
 matplotlib

--- a/thzpy/_unitchecks.py
+++ b/thzpy/_unitchecks.py
@@ -1,5 +1,6 @@
 """Simple functions for checking and correcting units."""
 
+
 def _check_thickness(thickness, unit):
     # Checks that a length unit is valid and applies it to a value.
     unit = unit.lower()

--- a/thzpy/frequencydomain/_frequencydomain.py
+++ b/thzpy/frequencydomain/_frequencydomain.py
@@ -9,7 +9,8 @@ import numpy as np
 
 def _n_complex(n, a, f):
     k = _extinction_coefficient(a, f)
-    return n + 1j*k 
+    return n + 1j*k
+
 
 def _extinction_coefficient(a, f):
     w = 2*np.pi*f
@@ -31,27 +32,29 @@ def _invert_dielectric_constant(e_complex):
 def _all_optical_constants(n, a, f, t, p):
     # Produce a dictionary of all optical constants.
     # Input arguments should all be in SI units
-    # Output arguments are in conventional units, e.g. absorption coefficients in cm-1, frequencies in THz
-    # Ouput arguments are also the output arguments of public functions
+    # Return values are in conventional units,
+    # e.g. absorption coefficients in cm-1, frequencies in THz.
 
-    k = _extinction_coefficient(a, f) 
+    k = _extinction_coefficient(a, f)
     n_complex = _n_complex(n, a, f)
     e_complex = _dielectric_constant(n_complex)
 
-    optical_constants = {"frequency": f*1e-12,
+    optical_constants = {"frequency": f*1e-12,  # units THz
                          "phase": p,
                          "transmission_amplitude": t,
                          "transmission_intensity": t**2,
-                         "absorption_coefficient": a*1e-2, # units cm-1
+                         "absorption_coefficient": a*1e-2,  # units cm-1
                          "extinction_coefficient": k,
                          "refractive_index": n_complex,
                          "dielectric_constant": e_complex}
 
     return optical_constants
 
+
 #########################
 # Effective medium theory
 #########################
+
 
 def _beer_lambert(e_eff, e_m, v_m, v_i):
     # Computes the dielectric spectrum of the unknown component

--- a/thzpy/frequencydomain/_frequencydomain.py
+++ b/thzpy/frequencydomain/_frequencydomain.py
@@ -30,21 +30,19 @@ def _invert_dielectric_constant(e_complex):
 
 def _all_optical_constants(n, a, f, t, p):
     # Produce a dictionary of all optical constants.
+    # Input arguments should all be in SI units
+    # Output arguments are in conventional units, e.g. absorption coefficients in cm-1, frequencies in THz
+    # Ouput arguments are also the output arguments of public functions
 
-    # convert units to SI
-    # define new parameters so that output parameters would not be affected    
-    f_hz = f*1e12 
-    a_m = a*100
-    
-    k = _extinction_coefficient(a_m, f_hz) 
-    n_complex = _n_complex(n, a_m, f_hz)
+    k = _extinction_coefficient(a, f) 
+    n_complex = _n_complex(n, a, f)
     e_complex = _dielectric_constant(n_complex)
 
-    optical_constants = {"frequency": f,
+    optical_constants = {"frequency": f*1e-12,
                          "phase": p,
                          "transmission_amplitude": t,
                          "transmission_intensity": t**2,
-                         "absorption_coefficient": a,
+                         "absorption_coefficient": a*1e-2, # units cm-1
                          "extinction_coefficient": k,
                          "refractive_index": n_complex,
                          "dielectric_constant": e_complex}

--- a/thzpy/timedomain/timedomain.py
+++ b/thzpy/timedomain/timedomain.py
@@ -253,13 +253,12 @@ def common_window(waveforms, half_width, start=None, end=None,
 
     # Find the new half width required to fit all waveforms.
     max_delay = max(peak_times) - min(peak_times)
-    common_half_width = half_width - max_delay/2
 
     # Window waveforms
     # TODO: Remove call to public function.
     for waveform in waveforms:
         windowed_waveforms.append(window(waveform,
-                                         common_half_width,
+                                         half_width,
                                          start,
                                          end,
                                          win_func,

--- a/thzpy/transferfunctions/_transferfunctions.py
+++ b/thzpy/transferfunctions/_transferfunctions.py
@@ -33,7 +33,7 @@ def _transform(sample, reference,
     phase = phase[valid_indices]
     amplitude = amplitude[valid_indices]
 
-    return amplitude, phase, freqs
+    return amplitude, phase, freqs*1e12
 
 
 def _unwrap(sample_fd, reference_fd,

--- a/thzpy/transferfunctions/_transmission.py
+++ b/thzpy/transferfunctions/_transmission.py
@@ -7,6 +7,9 @@ def _uniform_slab(amp, phase, freqs, thickness, n_med=1.,):
     # Calculates the complex refractive index for a homogenous slab.
     # TODO: Insert reference to Chi-Ki's paper.
 
+    # Ensure provided refractive indicex only uses the real component.
+    n_med = np.real(n_med)
+
     n = (299792458*phase)/(2*np.pi*freqs*thickness) + n_med
     a = (2/thickness)*np.log((4*n*n_med)/(amp*((n_med + n)**2)))
 
@@ -18,6 +21,10 @@ def _binary_mixture(amp, phase, freqs, t_sam, t_ref,
     # Calculates the complex refractive index for a slab
     # composed of two well mixed constituants.
     # TODO: Insert reference to Chi-Ki's paper.
+
+    # Ensure provided refractive indices only use the real component.
+    n_med = np.real(n_med)
+    n_ref = np.real(n_ref)
 
     n = ((299792458*phase)/(2*np.pi*freqs*t_sam)
          + (t_ref*(n_ref - n_med))/t_sam

--- a/thzpy/transferfunctions/_transmission.py
+++ b/thzpy/transferfunctions/_transmission.py
@@ -10,7 +10,7 @@ def _uniform_slab(amp, phase, freqs, thickness, n_med=1.,):
     n = (299792458*phase)/(2*np.pi*freqs*thickness) + n_med
     a = (2/thickness)*np.log((4*n*n_med)/(amp*((n_med + n)**2)))
 
-    return (n, a*1e-2)
+    return (n, a)
 
 
 def _binary_mixture(amp, phase, freqs, t_sam, t_ref,
@@ -25,4 +25,4 @@ def _binary_mixture(amp, phase, freqs, t_sam, t_ref,
     a = (a_ref*(t_ref/t_sam)
          + (2/t_sam)*np.log((n*((n_med+n_ref)**2))/(amp*n_ref*((n_med+n)**2))))
 
-    return (n, a*1e-2)
+    return (n, a)

--- a/thzpy/transferfunctions/_transmission.py
+++ b/thzpy/transferfunctions/_transmission.py
@@ -7,7 +7,7 @@ def _uniform_slab(amp, phase, freqs, thickness, n_med=1.,):
     # Calculates the complex refractive index for a homogenous slab.
     # TODO: Insert reference to Chi-Ki's paper.
 
-    # Ensure provided refractive indicex only uses the real component.
+    # Ensure provided refractive index only uses the real component.
     n_med = np.real(n_med)
 
     n = (299792458*phase)/(2*np.pi*freqs*thickness) + n_med

--- a/thzpy/transferfunctions/transferfunctions.py
+++ b/thzpy/transferfunctions/transferfunctions.py
@@ -83,8 +83,6 @@ def uniform_slab(thickness, sample, baseline,
                                    min_frequency=min_frequency,
                                    max_frequency=max_frequency)
     
-    freqs = freqs*1e12 # convert from THz to Hz
-    
     # Apply transfer function.
     n, a = _uniform_slab(amp, phase, freqs, thickness, n_med)
 
@@ -231,8 +229,6 @@ def binary_mixture(sample_thickness, reference_thickness,
                                        fit_range=fit_range,
                                        min_frequency=min_frequency,
                                        max_frequency=max_frequency)
-        
-        freqs = freqs*1e12 # convert from THz to Hz
         
         # Apply transfer function.
         n, a = _binary_mixture(amp, phase, freqs,

--- a/thzpy/transferfunctions/transferfunctions.py
+++ b/thzpy/transferfunctions/transferfunctions.py
@@ -82,12 +82,13 @@ def uniform_slab(thickness, sample, baseline,
                                    fit_range=fit_range,
                                    min_frequency=min_frequency,
                                    max_frequency=max_frequency)
-    
+
     # Apply transfer function.
     n, a = _uniform_slab(amp, phase, freqs, thickness, n_med)
 
     # Return optical constants.
-    # Output are in conventional units e.g. absorption coefficients in cm-1, frequencies in THz
+    # Output are in conventional units
+    # e.g. absorption coefficients in cm-1, frequencies in THz.
     if all_optical_constants:
         return _all_optical_constants(n, a, freqs, amp, phase)
     else:
@@ -219,8 +220,8 @@ def binary_mixture(sample_thickness, reference_thickness,
 
     else:
         # If no baseline is provided use approximation.
-        
-        a_ref = a_ref*1e2 # convert from cm-1 to m-1 
+
+        a_ref = a_ref*1e2   # convert from cm-1 to m-1
 
         # Transform to frequency domain.
         amp, phase, freqs = _transform(sample, reference,
@@ -229,7 +230,7 @@ def binary_mixture(sample_thickness, reference_thickness,
                                        fit_range=fit_range,
                                        min_frequency=min_frequency,
                                        max_frequency=max_frequency)
-        
+
         # Apply transfer function.
         n, a = _binary_mixture(amp, phase, freqs,
                                sample_thickness, reference_thickness,
@@ -255,7 +256,7 @@ def binary_mixture(sample_thickness, reference_thickness,
     n_sam = _invert_dielectric_constant(e_sam)
     n = np.real(n_sam)
     a = _absorption_coefficient(np.imag(n_sam), freqs)
-    
+
     # Return optical constants.
     if all_optical_constants:
         return _all_optical_constants(n, a, freqs, amp, phase)

--- a/thzpy/transferfunctions/transferfunctions.py
+++ b/thzpy/transferfunctions/transferfunctions.py
@@ -205,9 +205,6 @@ def binary_mixture(sample_thickness, reference_thickness,
                                                    min_frequency=min_frequency,
                                                    max_frequency=max_frequency)
 
-        freqs_mix = freqs_mix*1e12
-        freqs_ref = freqs_ref*1e12
-
         # Apply transfer function.
         n, a = _uniform_slab(amp_mix, phase_mix, freqs_mix,
                              sample_thickness, n_med)

--- a/thzpy/transferfunctions/transferfunctions.py
+++ b/thzpy/transferfunctions/transferfunctions.py
@@ -82,15 +82,18 @@ def uniform_slab(thickness, sample, baseline,
                                    fit_range=fit_range,
                                    min_frequency=min_frequency,
                                    max_frequency=max_frequency)
-
+    
+    freqs = freqs*1e12 # convert from THz to Hz
+    
     # Apply transfer function.
-    n, a = _uniform_slab(amp, phase, freqs*1e12, thickness, n_med)
+    n, a = _uniform_slab(amp, phase, freqs, thickness, n_med)
 
     # Return optical constants.
+    # Output are in conventional units e.g. absorption coefficients in cm-1, frequencies in THz
     if all_optical_constants:
         return _all_optical_constants(n, a, freqs, amp, phase)
     else:
-        return np.vstack([_n_complex(n, a, freqs), freqs])
+        return np.vstack([_n_complex(n, a, freqs), freqs*1e-12])
 
 
 def binary_mixture(sample_thickness, reference_thickness,
@@ -203,10 +206,13 @@ def binary_mixture(sample_thickness, reference_thickness,
                                                    min_frequency=min_frequency,
                                                    max_frequency=max_frequency)
 
+        freqs_mix = freqs_mix*1e12
+        freqs_ref = freqs_ref*1e12
+
         # Apply transfer function.
-        n, a = _uniform_slab(amp_mix, phase_mix, freqs_mix*1e12,
+        n, a = _uniform_slab(amp_mix, phase_mix, freqs_mix,
                              sample_thickness, n_med)
-        n_ref, a_ref = _uniform_slab(amp_ref, phase_ref, freqs_ref*1e12,
+        n_ref, a_ref = _uniform_slab(amp_ref, phase_ref, freqs_ref,
                                      reference_thickness, n_med)
 
         amp = amp_mix/amp_ref
@@ -215,6 +221,8 @@ def binary_mixture(sample_thickness, reference_thickness,
 
     else:
         # If no baseline is provided use approximation.
+        
+        a_ref = a_ref*1e2 # convert from cm-1 to m-1 
 
         # Transform to frequency domain.
         amp, phase, freqs = _transform(sample, reference,
@@ -223,15 +231,17 @@ def binary_mixture(sample_thickness, reference_thickness,
                                        fit_range=fit_range,
                                        min_frequency=min_frequency,
                                        max_frequency=max_frequency)
-
+        
+        freqs = freqs*1e12 # convert from THz to Hz
+        
         # Apply transfer function.
-        n, a = _binary_mixture(amp, phase, freqs*1e12,
+        n, a = _binary_mixture(amp, phase, freqs,
                                sample_thickness, reference_thickness,
                                n_med, n_ref, a_ref)
 
     # Convert to dielectric constant and apply effective medium theory.
-    e_mix = _dielectric_constant(_n_complex(n, a, freqs*1e12))
-    e_ref = _dielectric_constant(_n_complex(n_ref, a_ref, freqs*1e12))
+    e_mix = _dielectric_constant(_n_complex(n, a, freqs))
+    e_ref = _dielectric_constant(_n_complex(n_ref, a_ref, freqs))
 
     match effective_medium:
         case 'beer-lambert':
@@ -248,10 +258,10 @@ def binary_mixture(sample_thickness, reference_thickness,
     # Prepare optical constant values for returning.
     n_sam = _invert_dielectric_constant(e_sam)
     n = np.real(n_sam)
-    a = _absorption_coefficient(np.imag(n_sam), freqs*1e12)
+    a = _absorption_coefficient(np.imag(n_sam), freqs)
     
     # Return optical constants.
     if all_optical_constants:
         return _all_optical_constants(n, a, freqs, amp, phase)
     else:
-        return np.vstack([_n_complex(n, a, freqs), freqs])
+        return np.vstack([_n_complex(n, a, freqs), freqs*1e-12])


### PR DESCRIPTION
1. Ensures the same consistent halfwidth, which is specified by the user, is implemented in the windowing of each waveform when the def common_window is called

2. Update units used in public and private functions for consistency
Update all private functions such that input and output are all in SI units
Update all public functions such that input and output are in conventional units i.e. absorption coefficient in cm-1, frequency in THz
Exceptions:
`_transform`: frequency input and output are both in THz based on the consideration of computational efficiency
`_all_optical_constants`: input are in SI units and output are in conventional units. This is unique since the def takes in values from private functions and convert it to a form 